### PR TITLE
If error is retryable, do retry

### DIFF
--- a/src/main/java/org/embulk/output/s3_per_record/S3PerRecordOutputPlugin.java
+++ b/src/main/java/org/embulk/output/s3_per_record/S3PerRecordOutputPlugin.java
@@ -208,7 +208,7 @@ public class S3PerRecordOutputPlugin
                             Thread.sleep(retryWait);
                             retryWait = retryWait * 2;
                         } catch (InterruptedException e1) {
-                            throw new RuntimeException(e1);
+                            Thread.currentThread().interrupt();
                         }
                     } catch (InterruptedException | IOException e) {
                         throw new RuntimeException(e);


### PR DESCRIPTION
If error type is retryable (ex. Timeout or Serverside Exception), plugins do retry uploading.
It is more useful than current behavior.

Please review @tomykaira 
